### PR TITLE
Rework mouse handling

### DIFF
--- a/qml/components/Cell.qml
+++ b/qml/components/Cell.qml
@@ -16,22 +16,4 @@ Rectangle {
         font.pixelSize: 14
         visible: false
     }
-
-    MouseArea {
-        anchors.fill: parent
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
-        onEntered: model.state = field.drawingResult
-        hoverEnabled: field.drawingEnabled
-        onPressed: (mouseEvent) => {
-            if (field.drawingEnabled) {
-                field.drawingEnabled = false;
-            } else {
-                // Hovering on other cells doen't work if the event is accepted
-                mouseEvent.accepted = false;
-                field.drawingResult = mouseEvent.button === Qt.LeftButton;
-                field.drawingEnabled = true;
-                onEntered();
-            }
-        }
-    }
 }

--- a/qml/components/Field.qml
+++ b/qml/components/Field.qml
@@ -11,6 +11,7 @@ Rectangle {
     // TODO State enum
     property int drawingResult: 0
     readonly property int cellSize: 24
+    readonly property int fullCellSize: cellSize + 1
 
     TableView {
         id: table
@@ -32,6 +33,58 @@ Rectangle {
             anchors.margins: -1
             radius: 2
             color: colors.field_bg
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+
+            property int last_row: 0
+            property int last_col: 0
+
+            onPressed:
+                (mouse) => {
+                    last_row = Math.floor(mouse.y / fullCellSize)
+                    last_col = Math.floor(mouse.x / fullCellSize)
+                    field.drawingResult = mouse.button === Qt.LeftButton;
+                    field.drawingEnabled = true;
+                }
+
+            onReleased:
+                (mouse) => {
+                    field.drawingEnabled = false;
+                }
+
+            onPositionChanged:
+                (mouse) => {
+                    let row = Math.floor(mouse.y / fullCellSize)
+                    let col = Math.floor(mouse.x / fullCellSize)
+
+                    let row_step = last_row < row ? 1 : -1
+                    let col_step = last_col < col ? 1 : -1
+
+                    let col_k = 0
+                    let max_k = Math.abs((row - last_row) / (col - last_col))
+                    let cur_row = last_row
+                    let cur_col = last_col
+
+                    while (true) {
+                        _fieldModel.setStateAt(cur_row, cur_col, drawingResult)
+
+                        if (cur_row === row && cur_col === col) break
+
+                        if (Math.abs(cur_row - row) > Math.abs(cur_col - col) && col_k <= max_k) {
+                            col_k += 1
+                            cur_row += row_step
+                        } else {
+                            col_k = 0
+                            cur_col += col_step
+                        }
+                    }
+
+                    last_row = row
+                    last_col = col
+                }
         }
     }
 

--- a/src/models/fieldmodel.cpp
+++ b/src/models/fieldmodel.cpp
@@ -70,6 +70,11 @@ void FieldModel::resize(int rows, int cols)
     else if (cols < oldCols) endRemoveColumns();
 }
 
+void FieldModel::setStateAt(int row, int col, Cell::State state)
+{
+    setData(index(row, col), state, Roles::StateRole);
+}
+
 void FieldModel::clearField()
 {
     field.clear();

--- a/src/models/fieldmodel.h
+++ b/src/models/fieldmodel.h
@@ -22,6 +22,7 @@ public:
     bool setData(const QModelIndex &index, const QVariant &value, int role);
     QHash<int, QByteArray> roleNames() const;
     Q_INVOKABLE void resize(int rows, int cols);
+    Q_INVOKABLE void setStateAt(int row, int col, Cell::State state);
 
 public slots:
     void clearField();


### PR DESCRIPTION
- Remove MouseAreas of Cells
- Add MouseArea for the TableView
- Add FieldModel::setStateAt()
- Propagate mouse drawing to cells through FielModel::setStateAt()
- Generate smooth lines between registered drawing points (Fixes #6)